### PR TITLE
Allow mapping of public IPs to be an option

### DIFF
--- a/aws_subnet_public.tf
+++ b/aws_subnet_public.tf
@@ -3,7 +3,7 @@ resource "aws_subnet" "public" {
   vpc_id                  = aws_vpc.main.id
   cidr_block              = local.public_cidrs[count.index]
   availability_zone       = data.aws_availability_zones.available.names[count.index]
-  map_public_ip_on_launch = true
+  map_public_ip_on_launch = var.subnet_map_public_ip_on_launch
 
   tags = merge(
     var.common_tags,

--- a/variables.tf
+++ b/variables.tf
@@ -87,6 +87,12 @@ variable "vpc_endpoint_dynamodb_enabled" {
   default     = 0
 }
 
+variable "subnet_map_public_ip_on_launch" {
+  description = "Whether public subnets should allocate a public ip when instances launch"
+  type        = bool
+  default     = true
+}
+
 locals {
   public_cidrs  = [cidrsubnet(var.cidr, 3, 0), cidrsubnet(var.cidr, 3, 1), cidrsubnet(var.cidr, 3, 2)]
   private_cidrs = [cidrsubnet(var.cidr, 3, 3), cidrsubnet(var.cidr, 3, 4), cidrsubnet(var.cidr, 3, 5)]


### PR DESCRIPTION
Some users require public subnets that do not automatically allocate IPs